### PR TITLE
Make Affirm checkouts non-reusable

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@
 
 AllCops:
   Exclude:
+    - 'solidus_affirm.gemspec'
     - 'spec/dummy/**/*'
     - 'vendor/bundle/**/*'
   TargetRubyVersion: 2.1

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -59,28 +59,28 @@ Style/AsciiComments:
 Lint/EndAlignment:
   Enabled: false
 
-Style/ElseAlignment:
+Layout/ElseAlignment:
   Enabled: false
 
-Style/IndentationWidth:
+Layout/IndentationWidth:
   Enabled: false
 
-Style/AlignParameters:
+Layout/AlignParameters:
   Enabled: false
 
-Style/ClosingParenthesisIndentation:
+Layout/ClosingParenthesisIndentation:
   Enabled: false
 
-Style/MultilineMethodCallIndentation:
+Layout/MultilineMethodCallIndentation:
   Enabled: false
 
-Style/IndentArray:
+Layout/IndentArray:
   Enabled: false
 
-Style/IndentHash:
+Layout/IndentHash:
   Enabled: false
 
-Style/AlignHash:
+Layout/AlignHash:
   Enabled: false
 
 # From http://relaxed.ruby.style/
@@ -101,7 +101,7 @@ Style/Documentation:
   Enabled: false
   StyleGuide: http://relaxed.ruby.style/#styledocumentation
 
-Style/DotPosition:
+Layout/DotPosition:
   Enabled: false
   StyleGuide: http://relaxed.ruby.style/#styledotposition
 
@@ -169,11 +169,11 @@ Style/SingleLineMethods:
   Enabled: false
   StyleGuide: http://relaxed.ruby.style/#stylesinglelinemethods
 
-Style/SpaceBeforeBlockBraces:
+Layout/SpaceBeforeBlockBraces:
   Enabled: false
   StyleGuide: http://relaxed.ruby.style/#stylespacebeforeblockbraces
 
-Style/SpaceInsideParens:
+Layout/SpaceInsideParens:
   Enabled: false
   StyleGuide: http://relaxed.ruby.style/#stylespaceinsideparens
 

--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,7 @@ source 'https://rubygems.org'
 branch = ENV.fetch("SOLIDUS_BRANCH", "master")
 gem 'solidus', github: 'solidusio/solidus', branch: branch
 
-if branch == 'master' || branch >= "v2.3"
-  gem "rails-controller-testing", group: :test
-elsif branch >= "v2.0"
+if branch == 'master' || branch >= "v2.0"
   gem "rails-controller-testing", group: :test
 else
   gem "rails_test_params_backport", group: :test

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,15 @@
 source 'https://rubygems.org'
 
-gem 'solidus', github: 'solidusio/solidus', branch: ENV.fetch('SOLIDUS_BRANCH', 'master')
+branch = ENV.fetch("SOLIDUS_BRANCH", "master")
+gem 'solidus', github: 'solidusio/solidus', branch: branch
+
+if branch == 'master' || branch >= "v2.3"
+  gem "rails-controller-testing", group: :test
+elsif branch >= "v2.0"
+  gem "rails-controller-testing", group: :test
+else
+  gem "rails_test_params_backport", group: :test
+end
 
 gem 'mysql2'
 gem 'pg'

--- a/app/models/solidus_affirm/checkout.rb
+++ b/app/models/solidus_affirm/checkout.rb
@@ -2,6 +2,10 @@ module SolidusAffirm
   class Checkout < ActiveRecord::Base
     self.table_name = "affirm_checkouts"
 
+    def reusable?
+      false
+    end
+
     def actions
       %w(capture void credit)
     end

--- a/db/migrate/20170117145716_create_affirm_checkouts.rb
+++ b/db/migrate/20170117145716_create_affirm_checkouts.rb
@@ -1,4 +1,4 @@
-class CreateAffirmCheckouts < ActiveRecord::Migration
+class CreateAffirmCheckouts < SolidusSupport::Migration[4.2]
   def change
     create_table :affirm_checkouts do |t|
       t.string :token

--- a/lib/generators/solidus_affirm/install/install_generator.rb
+++ b/lib/generators/solidus_affirm/install/install_generator.rb
@@ -13,10 +13,6 @@ module SolidusAffirm
         inject_into_file 'vendor/assets/stylesheets/spree/backend/all.css', " *= require spree/backend/solidus_affirm\n", before: /\*\//, verbose: true
       end
 
-      def add_gateway
-        append_file 'config/initializers/spree.rb', "Rails.application.config.spree.payment_methods << SolidusAffirm::Gateway"
-      end
-
       def add_migrations
         run 'bundle exec rake railties:install:migrations FROM=solidus_affirm'
       end

--- a/lib/solidus_affirm.rb
+++ b/lib/solidus_affirm.rb
@@ -1,4 +1,5 @@
 require 'solidus_core'
+require 'solidus_support'
 require 'solidus_affirm/engine'
 require 'solidus_affirm/callback_hook/base'
 require 'solidus_affirm/affirm_client'

--- a/lib/solidus_affirm/engine.rb
+++ b/lib/solidus_affirm/engine.rb
@@ -15,6 +15,10 @@ module SolidusAffirm
       SolidusAffirm::Config = SolidusAffirm::Configuration.new
     end
 
+    initializer "register_solidus_affirm_gateway", after: "spree.register.payment_methods" do |app|
+      app.config.spree.payment_methods << SolidusAffirm::Gateway
+    end
+
     initializer 'spree.solidus_affirm.action_controller' do |_app|
       ActiveSupport.on_load :action_controller do |klass|
         next if klass.name == "ActionController::API"

--- a/solidus_affirm.gemspec
+++ b/solidus_affirm.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir['test/**/*']
 
   s.add_dependency 'solidus', ['>= 1.1', '< 3']
+  s.add_dependency 'solidus_support'
   s.add_dependency 'active_model_serializers', '~> 0.10'
   s.add_dependency 'affirm-ruby', '1.0.2'
 

--- a/spec/models/solidus_affirm/checkout_spec.rb
+++ b/spec/models/solidus_affirm/checkout_spec.rb
@@ -3,6 +3,12 @@ require 'spec_helper'
 RSpec.describe SolidusAffirm::Checkout do
   subject { SolidusAffirm::Checkout.new }
 
+  describe "#reusable?" do
+    it "is never reusable" do
+      expect(subject.reusable?).to eq(false)
+    end
+  end
+
   it "supports the capture, void and credit actions" do
     expect(subject.actions).to eql ["capture", "void", "credit"]
   end

--- a/spec/requests/affirm_controller_spec.rb
+++ b/spec/requests/affirm_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Spree::AffirmController do
     context 'when the order_id is not valid' do
       it "will raise an AR RecordNotFound" do
         expect {
-          post '/affirm/confirm', {
+          post '/affirm/confirm', params: {
             checkout_token: checkout_token,
             payment_method_id: payment_method.id,
             order_id: nil,
@@ -21,7 +21,7 @@ RSpec.describe Spree::AffirmController do
 
     context 'when the checkout_token is missing' do
       it "will redirect to the order current checkout state path" do
-        post '/affirm/confirm', {
+        post '/affirm/confirm', params: {
           checkout_token: nil,
           payment_method_id: payment_method.id,
           order_id: order.id,
@@ -35,7 +35,7 @@ RSpec.describe Spree::AffirmController do
       let(:order) { create(:completed_order_with_totals) }
 
       it 'will redirect to the order detail page' do
-        post '/affirm/confirm', {
+        post '/affirm/confirm', params: {
           checkout_token: checkout_token,
           payment_method_id: payment_method.id,
           order_id: order.id,
@@ -59,7 +59,7 @@ RSpec.describe Spree::AffirmController do
 
       it "redirect to the confirm page" do
         VCR.use_cassette 'callback_hook_authorize_success' do
-          post '/affirm/confirm', {
+          post '/affirm/confirm', params: {
             checkout_token: checkout_token,
             payment_method_id: payment_method.id,
             order_id: order.id,
@@ -74,7 +74,7 @@ RSpec.describe Spree::AffirmController do
   describe 'GET cancel' do
     context "with an order_id present" do
       it "will redirect to the current order checkout state" do
-        get '/affirm/cancel', {
+        get '/affirm/cancel', params: {
           payment_method_id: payment_method.id,
           order_id: order.id,
           use_route: :spree


### PR DESCRIPTION
This commit into Solidus core:
https://github.com/solidusio/solidus/commit/547d459c26b2f48bbe2a75b58c90063f678fced2

Introduced a check if payment sources are `reusable?`. The Checkout
model here is used as the source, but doesn't implement that method,
which causes any code that calls this to throw a method missing error.
In particular I've seen this occur on the /admin/payments/new page.