### PR TITLE
Change payment void params order

### DIFF
--- a/lib/solidus_affirm/affirm_client.rb
+++ b/lib/solidus_affirm/affirm_client.rb
@@ -32,7 +32,7 @@ module SolidusAffirm
       end
     end
 
-    def void(_money, charge_id, _options = {})
+    def void(charge_id, _money, _options = {})
       response = ::Affirm::Charge.void(charge_id)
       if response.success?
         return ActiveMerchant::Billing::Response.new(true, "Transaction Voided")

--- a/spec/lib/solidus_affirm/affirm_client_spec.rb
+++ b/spec/lib/solidus_affirm/affirm_client_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe SolidusAffirm::AffirmClient do
       let(:charge_id) { "X0KF-8HQY" }
       it "will void the payment in Affirm" do
         VCR.use_cassette("valid_void") do
-          response = subject.void(nil, charge_id, {})
+          response = subject.void(charge_id, nil, {})
           expect(response.success?).to be_truthy
         end
       end
@@ -83,14 +83,14 @@ RSpec.describe SolidusAffirm::AffirmClient do
     context "on a captured payment" do
       it "will return an unsuccesfull response" do
         VCR.use_cassette("invalid_void") do
-          response = subject.void(nil, charge_id, {})
+          response = subject.void(charge_id, nil, {})
           expect(response.success?).to be_falsey
         end
       end
 
       it "will return the error message from Affirm in the response" do
         VCR.use_cassette("invalid_void") do
-          response = subject.void(nil, charge_id, {})
+          response = subject.void(charge_id, nil, {})
           expect(response.message).to eql "Cannot void captured charge"
         end
       end


### PR DESCRIPTION
I'm changing SolidusAffirm::AffirmClient.void params order.
Now Solidus' void call and Affirm's void params are matching.