### PR TITLE
Add cancel support

### DIFF
--- a/app/models/solidus_affirm/gateway.rb
+++ b/app/models/solidus_affirm/gateway.rb
@@ -41,7 +41,7 @@ module SolidusAffirm
     #
     # If the transaction has not yet been captured, we can void the transaction.
     # Otherwise, we need to issue a refund.
-    def cancel(charge_id)
+    def cancel(charge_id, try_credit = true)
       provider
 
       begin
@@ -59,8 +59,12 @@ module SolidusAffirm
       if voidable?(transaction)
         void(charge_id, nil, {})
       else
-        credit(nil, charge_id, {})
+        try_credit ? credit(nil, charge_id, {}) : false
       end
+    end
+
+    def try_void(charge_id)
+      cancel(charge_id, false)
     end
 
     private

--- a/spec/fixtures/vcr_casettes/invalid_find.yml
+++ b/spec/fixtures/vcr_casettes/invalid_find.yml
@@ -1,0 +1,44 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://sandbox.affirm.com/api/v2/charges/fake_transaction_id
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic WFBTUTNDQTdQTE43Q0pDSzp3OW14a1FVcnlLalRZRHFPZlN2WVRlVEdvTElVUktwVQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Cache-Control:
+      - max-age=600
+      Content-Type:
+      - application/xml
+      Date:
+      - Wed, 17 Jan 2018 13:54:43 GMT
+      Server:
+      - openresty
+      X-Affirm-Request-Id:
+      - dfda7507-2a23-47d8-c78b-2d5d5d2c0381
+      Content-Length:
+      - '410'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="UTF-8"?>
+        <Error><Code>InvalidArgument</Code><Message>Unsupported Authorization Type</Message><ArgumentName>Authorization</ArgumentName><ArgumentValue>Basic WFBTUTNDQTdQTE43Q0pDSzp3OW14a1FVcnlLalRZRHFPZlN2WVRlVEdvTElVUktwVQ==</ArgumentValue><RequestId>ECE3843D14E0AED6</RequestId><HostId>KTUevYp9hAcrYjkYRQXS542DiwmEdASjhORticMNPXId8QEICwwuyd0X/s0nVBUBfRPay/Bpkzs=</HostId></Error>
+    http_version: 
+  recorded_at: Wed, 17 Jan 2018 13:54:44 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_casettes/valid_find_authorized.yml
+++ b/spec/fixtures/vcr_casettes/valid_find_authorized.yml
@@ -1,0 +1,67 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://sandbox.affirm.com/api/v2/charges/GOH6-7PUX
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic WFBTUTNDQTdQTE43Q0pDSzp3OW14a1FVcnlLalRZRHFPZlN2WVRlVEdvTElVUktwVQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 17 Jan 2018 13:50:42 GMT
+      Server:
+      - openresty
+      Strict-Transport-Security:
+      - max-age=86400
+      X-Affirm-Request-Id:
+      - 2712219f-bd8a-485c-c819-02efcdc4381e
+      Content-Length:
+      - '2020'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"currency": "USD", "id": "GOH6-7PUX", "under_dispute": false, "user_id":
+        "7058-0675-OWZI", "details": {"merchant": {"public_api_key": "XPSQ3CA7PLN7CJCK",
+        "user_cancel_url": "http://localhost:3000/affirm/cancel?order_id=4&payment_method_id=4",
+        "user_confirmation_url": "http://localhost:3000/affirm/confirm?order_id=4&payment_method_id=4",
+        "name": "[TEST] Stembolt"}, "tax_amount": 1025, "billing": {"name": {"full":
+        "Peter Berkenbosch", "last": "Berkenbosch", "first": "Peter"}, "address":
+        {"city": "New York", "country": "USA", "zipcode": "10001", "line1": "20 W
+        29th St", "line2": "", "state": "NY"}}, "checkout_type": "merchant", "order_id":
+        "R972553602", "items": {"ROR-00015": {"sku": "ROR-00015", "item_url": "http://localhost:3000/products/ruby-on-rails-ringer-t-shirt",
+        "display_name": "Ruby on Rails Ringer T-Shirt", "unit_price": 1999, "qty":
+        10, "item_type": "physical", "item_image_url": "/spree/products/29/large/ror_ringer.jpeg?1486153070"}},
+        "shipping": {"name": {"full": "Peter Berkenbosch", "last": "Berkenbosch",
+        "first": "Peter"}, "address": {"city": "New York", "country": "USA", "zipcode":
+        "10001", "line1": "20 W 29th St", "line2": "", "state": "NY"}}, "currency":
+        "USD", "meta": {"release": "true", "user_timezone": "America/New_York", "__affirm_tracking_uuid":
+        "35f9a44b-586a-46e9-bdd2-1cf76804f756"}, "shipping_amount": 500, "total":
+        21515, "config": {}, "api_version": "v2", "merchant_external_reference": "R972553602"},
+        "refundable": false, "charge_event_count": 0, "events": [{"created": "2017-02-06T18:21:53Z",
+        "currency": "USD", "amount": 21515, "type": "auth", "id": "W7P0TG12F5TQIVZ7",
+        "transaction_id": "uuHtqhqUsAuqXMz7"}], "pending": true, "merchant_external_reference":
+        "R972553602", "status": "authorized", "order_id": "R972553602", "void": false,
+        "expires": "2017-03-08T18:21:54Z", "payable": 0, "merchant_id": "3VXA5KS4ZA7IZLA3",
+        "auth_hold": 21515, "refunded_amount": 0, "created": "2017-02-06T18:21:32Z",
+        "amount": 21515, "balance": 21515, "financing_program": "default_3_6_12"}'
+    http_version: 
+  recorded_at: Wed, 17 Jan 2018 13:50:42 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_casettes/valid_find_captured.yml
+++ b/spec/fixtures/vcr_casettes/valid_find_captured.yml
@@ -1,0 +1,74 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://sandbox.affirm.com/api/v2/charges/N330-Z6D4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic WFBTUTNDQTdQTE43Q0pDSzp3OW14a1FVcnlLalRZRHFPZlN2WVRlVEdvTElVUktwVQ==
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 17 Jan 2018 13:44:59 GMT
+      Server:
+      - openresty
+      Strict-Transport-Security:
+      - max-age=86400
+      X-Affirm-Request-Id:
+      - '0884af71-a34a-490b-c9a4-a419d894a8ee'
+      Content-Length:
+      - '2576'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"currency": "USD", "id": "N330-Z6D4", "under_dispute": false, "user_id":
+        "7058-0675-OWZI", "details": {"merchant": {"public_api_key": "XPSQ3CA7PLN7CJCK",
+        "user_cancel_url": "http://localhost:3000/affirm/cancel?order_id=12&payment_method_id=4",
+        "user_confirmation_url": "http://localhost:3000/affirm/confirm?order_id=12&payment_method_id=4",
+        "name": "[TEST] Stembolt"}, "tax_amount": 2024, "billing": {"name": {"full":
+        "Peter Berkenbosch", "last": "Berkenbosch", "first": "Peter"}, "address":
+        {"city": "New York", "country": "USA", "zipcode": "10001", "line1": "20 W
+        29th St", "line2": "", "state": "NY"}}, "checkout_type": "merchant", "order_id":
+        "R368883147", "items": {"ROR-00011": {"sku": "ROR-00011", "item_url": "http://9cfb58bc.ngrok.io/products/ruby-on-rails-tote",
+        "display_name": "Ruby on Rails Tote", "unit_price": 1599, "qty": 25, "item_type":
+        "physical", "item_image_url": "/spree/products/21/large/ror_tote.jpeg?1485939804"}},
+        "shipping": {"name": {"full": "Peter Berkenbosch", "last": "Berkenbosch",
+        "first": "Peter"}, "address": {"city": "New York", "country": "USA", "zipcode":
+        "10001", "line1": "20 W 29th St", "line2": "", "state": "NY"}}, "currency":
+        "USD", "meta": {"release": "true", "user_timezone": "America/New_York", "__affirm_tracking_uuid":
+        "35f9a44b-586a-46e9-bdd2-1cf76804f756"}, "shipping_amount": 500, "total":
+        42499, "config": {}, "api_version": "v2", "merchant_external_reference": "R368883147"},
+        "refundable": true, "charge_event_count": 0, "events": [{"created": "2017-02-02T20:17:07Z",
+        "currency": "USD", "amount": 42499, "type": "auth", "id": "Q9QRCO9ZKTBVGME4",
+        "transaction_id": "5Mx10EEnyZUsfqbH"}, {"fee": 1275, "created": "2017-02-02T20:46:12Z",
+        "currency": "USD", "amount": 42499, "type": "capture", "id": "7DOHCZFER4H7JM99",
+        "transaction_id": "Vdoadw3u72HiW1LP"}, {"created": "2017-02-02T21:11:09Z",
+        "fee_refunded": 30, "currency": "USD", "amount": 1000, "type": "refund", "id":
+        "Q9V5OSY77YIZN8S0", "transaction_id": "tFpFOCQrW3b8UxDU"}, {"created": "2017-02-12T20:32:03Z",
+        "fee_refunded": 300, "currency": "USD", "amount": 10000, "type": "refund",
+        "id": "VAY5XGUBO91LR7FI", "transaction_id": "eheCV4sVKPlBIXWe"}], "pending":
+        false, "merchant_external_reference": "R368883147", "status": "partially refunded",
+        "order_id": "R368883147", "void": false, "expires": "2017-03-04T20:17:08Z",
+        "payable": 30554, "merchant_id": "3VXA5KS4ZA7IZLA3", "refund_expires": "2017-06-02T20:46:12Z",
+        "auth_hold": 0, "refunded_amount": 11000, "created": "2017-02-02T14:59:44Z",
+        "amount": 42499, "balance": 31499, "financing_program": "default_3_6_12"}'
+    http_version: 
+  recorded_at: Wed, 17 Jan 2018 13:44:59 GMT
+recorded_with: VCR 4.0.0

--- a/spec/models/solidus_affirm/gateway_spec.rb
+++ b/spec/models/solidus_affirm/gateway_spec.rb
@@ -1,0 +1,49 @@
+require "spec_helper"
+
+RSpec.describe SolidusAffirm::Gateway do
+  let(:gateway) do
+    create(:affirm_payment_gateway,
+           preferred_public_api_key: "XPSQ3CA7PLN7CJCK",
+           preferred_private_api_key: "w9mxkQUryKjTYDqOfSvYTeTGoLIURKpU")
+  end
+  let(:authorized_id) { "GOH6-7PUX" }
+  let(:captured_id) { "N330-Z6D4" }
+
+  describe "#cancel" do
+    let(:transaction_id) { "fake_transaction_id" }
+
+    subject(:cancel) { gateway.cancel(transaction_id) }
+
+    context "when the transaction is found" do
+      context "and it is voidable" do
+        let(:transaction_id) { authorized_id }
+
+        it "voids the transaction" do
+          VCR.use_cassette("valid_find_authorized") do
+            expect(gateway).to receive(:void).with(transaction_id, nil, {})
+            cancel
+          end
+        end
+      end
+
+      context "and it is not voidable" do
+        let(:transaction_id) { captured_id }
+
+        it "refunds the transaction" do
+          VCR.use_cassette("valid_find_captured") do
+            expect(gateway).to receive(:credit).with(nil, transaction_id, {})
+            cancel
+          end
+        end
+      end
+    end
+
+    context "when the transaction is not found" do
+      it "raises an error" do
+        VCR.use_cassette("invalid_find") do
+          expect(cancel.message).to eq "Affirm charge not found"
+        end
+      end
+    end
+  end
+end

--- a/spec/models/solidus_affirm/gateway_spec.rb
+++ b/spec/models/solidus_affirm/gateway_spec.rb
@@ -46,4 +46,41 @@ RSpec.describe SolidusAffirm::Gateway do
       end
     end
   end
+
+  describe "#try_void" do
+    let(:transaction_id) { "fake_transaction_id" }
+
+    subject(:try_void) { gateway.try_void(transaction_id) }
+
+    context "when the transaction is found" do
+      context "and it is voidable" do
+        let(:transaction_id) { authorized_id }
+
+        it "voids the transaction" do
+          VCR.use_cassette("valid_find_authorized") do
+            expect(gateway).to receive(:void).with(transaction_id, nil, {})
+            try_void
+          end
+        end
+      end
+
+      context "and it is not voidable" do
+        let(:transaction_id) { captured_id }
+
+        it "returns false" do
+          VCR.use_cassette("valid_find_captured") do
+            expect(try_void).to be false
+          end
+        end
+      end
+    end
+
+    context "when the transaction is not found" do
+      it "raises an error" do
+        VCR.use_cassette("invalid_find") do
+          expect(try_void.message).to eq "Affirm charge not found"
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR adds the ability to cancel orders paid with Affirm by implementing the #cancel and #try_void methods on the gateway.

We currently get an exception if we try to cancel Affirm orders (missing method #cancel).