### PR TITLE
Fix rubocop warnings and remove 1.x support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -56,28 +56,28 @@ Style/AsciiComments:
 Lint/EndAlignment:
   Enabled: false
 
-Style/ElseAlignment:
+Layout/ElseAlignment:
   Enabled: false
 
-Style/IndentationWidth:
+Layout/IndentationWidth:
   Enabled: false
 
-Style/AlignParameters:
+Layout/AlignParameters:
   Enabled: false
 
-Style/ClosingParenthesisIndentation:
+Layout/ClosingParenthesisIndentation:
   Enabled: false
 
-Style/MultilineMethodCallIndentation:
+Layout/MultilineMethodCallIndentation:
   Enabled: false
 
-Style/IndentArray:
+Layout/IndentArray:
   Enabled: false
 
-Style/IndentHash:
+Layout/IndentHash:
   Enabled: false
 
-Style/AlignHash:
+Layout/AlignHash:
   Enabled: false
 
 # From http://relaxed.ruby.style/
@@ -98,7 +98,7 @@ Style/Documentation:
   Enabled: false
   StyleGuide: http://relaxed.ruby.style/#styledocumentation
 
-Style/DotPosition:
+Layout/DotPosition:
   Enabled: false
   StyleGuide: http://relaxed.ruby.style/#styledotposition
 
@@ -166,11 +166,11 @@ Style/SingleLineMethods:
   Enabled: false
   StyleGuide: http://relaxed.ruby.style/#stylesinglelinemethods
 
-Style/SpaceBeforeBlockBraces:
+Layout/SpaceBeforeBlockBraces:
   Enabled: false
   StyleGuide: http://relaxed.ruby.style/#stylespacebeforeblockbraces
 
-Style/SpaceInsideParens:
+Layout/SpaceInsideParens:
   Enabled: false
   StyleGuide: http://relaxed.ruby.style/#stylespaceinsideparens
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@
 
 AllCops:
   Exclude:
+    - 'solidus_affirm.gemspec'
     - 'spec/dummy/**/*'
     - 'vendor/bundle/**/*'
   TargetRubyVersion: 2.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ rvm:
   - 2.3.1
 env:
   matrix:
-    - SOLIDUS_BRANCH=v1.4 DB=postgres
     - SOLIDUS_BRANCH=v2.0 DB=postgres
     - SOLIDUS_BRANCH=v2.1 DB=postgres
     - SOLIDUS_BRANCH=v2.2 DB=postgres
@@ -12,7 +11,6 @@ env:
     - SOLIDUS_BRANCH=v2.4 DB=postgres
     - SOLIDUS_BRANCH=v2.5 DB=postgres
     - SOLIDUS_BRANCH=master DB=postgres
-    - SOLIDUS_BRANCH=v1.4 DB=mysql
     - SOLIDUS_BRANCH=v2.0 DB=mysql
     - SOLIDUS_BRANCH=v2.1 DB=mysql
     - SOLIDUS_BRANCH=v2.2 DB=mysql

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,12 @@ branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
 
 gem 'solidus', github: 'solidusio/solidus', branch: branch
 
+if branch == 'master' || branch >= "v2.0"
+  gem "rails-controller-testing", group: :test
+else
+  gem "rails_test_params_backport", group: :test
+end
+
 gem 'mysql2'
 gem 'pg', '~> 0.21'
 

--- a/Gemfile
+++ b/Gemfile
@@ -17,10 +17,4 @@ group :development, :test do
   gem "pry-rails"
 end
 
-group :test do
-  if branch == 'v1.4'
-   gem 'rails_test_params_backport', group: :test
-  end
-end
-
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -4,11 +4,7 @@ branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
 
 gem 'solidus', github: 'solidusio/solidus', branch: branch
 
-if branch == 'master' || branch >= "v2.0"
-  gem "rails-controller-testing", group: :test
-else
-  gem "rails_test_params_backport", group: :test
-end
+gem "rails-controller-testing", group: :test
 
 gem 'mysql2'
 gem 'pg', '~> 0.21'

--- a/solidus_affirm.gemspec
+++ b/solidus_affirm.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'active_model_serializers', '~> 0.10'
   s.add_dependency 'affirm-ruby', '1.0.2'
-  s.add_dependency 'solidus', ['>= 1.1', '< 3']
+  s.add_dependency 'solidus', ['>= 2.0', '< 3']
   s.add_dependency "solidus_support"
 
   s.add_development_dependency 'capybara'

--- a/spec/serializers/solidus_affirm/checkout_payload_serializer_spec.rb
+++ b/spec/serializers/solidus_affirm/checkout_payload_serializer_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe SolidusAffirm::CheckoutPayloadSerializer do
 
     context 'on an order with promotions' do
       before do
-        expect(order).to receive(:promo_total).and_return(BigDecimal.new("100.00"))
+        expect(order).to receive(:promo_total).and_return(BigDecimal("100.00"))
       end
 
       it "will aggregate the promotions into the discounts key" do

--- a/spec/serializers/solidus_affirm/line_item_serializer_spec.rb
+++ b/spec/serializers/solidus_affirm/line_item_serializer_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe SolidusAffirm::LineItemSerializer do
-  let(:line_item) { create(:line_item, price: BigDecimal.new('14.99')) }
+  let(:line_item) { create(:line_item, price: BigDecimal('14.99')) }
   let(:serializer) { SolidusAffirm::LineItemSerializer.new(line_item, root: false) }
   subject { JSON.parse(serializer.to_json) }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,7 +13,7 @@ end
 # Configure Rails Environment
 ENV['RAILS_ENV'] = 'test'
 
-require File.expand_path('../dummy/config/environment.rb', __FILE__)
+require File.expand_path('dummy/config/environment.rb', __dir__)
 
 require 'rspec/rails'
 require 'database_cleaner'


### PR DESCRIPTION
I've fixed the Travis build by removing all rubocop offences, also taking some commits from #7. 

cc @luukveenis