### PR TITLE
Install payment method into the right initializer

### DIFF
--- a/lib/generators/solidus_affirm/install/install_generator.rb
+++ b/lib/generators/solidus_affirm/install/install_generator.rb
@@ -13,10 +13,6 @@ module SolidusAffirm
         inject_into_file 'vendor/assets/stylesheets/spree/backend/all.css', " *= require spree/backend/solidus_affirm\n", before: /\*\//, verbose: true
       end
 
-      def add_gateway
-        append_file 'config/initializers/spree.rb', "Rails.application.config.spree.payment_methods << SolidusAffirm::Gateway"
-      end
-
       def add_migrations
         run 'bundle exec rake railties:install:migrations FROM=solidus_affirm'
       end

--- a/lib/solidus_affirm/engine.rb
+++ b/lib/solidus_affirm/engine.rb
@@ -15,6 +15,10 @@ module SolidusAffirm
       SolidusAffirm::Config = SolidusAffirm::Configuration.new
     end
 
+    initializer "register_solidus_affirm_gateway", after: "spree.register.payment_methods" do |app|
+      app.config.spree.payment_methods << SolidusAffirm::Gateway
+    end
+
     initializer 'spree.solidus_affirm.action_controller' do |_app|
       ActiveSupport.on_load :action_controller do |klass|
         next if klass.name == "ActionController::API"


### PR DESCRIPTION
In solidus 2.3+, `spree.rb` initilalizer has been replaced by `solidus.rb`.
This change makes it possible to install the extension correctly in newer versions.

This is an alternative approach to https://github.com/solidusio-contrib/solidus_affirm/pull/7/commits/0475f50df4b83de24f1f6e9430ccb74fce3d2e81.

