### PR TITLE
Fix Gateway#try_void expecting a charge ID instead of a payment

### DIFF
--- a/app/models/solidus_affirm/gateway.rb
+++ b/app/models/solidus_affirm/gateway.rb
@@ -63,8 +63,8 @@ module SolidusAffirm
       end
     end
 
-    def try_void(charge_id)
-      cancel(charge_id, false)
+    def try_void(payment)
+      cancel(payment.response_code, false)
     end
 
     private

--- a/spec/models/solidus_affirm/gateway_spec.rb
+++ b/spec/models/solidus_affirm/gateway_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe SolidusAffirm::Gateway do
   describe "#try_void" do
     let(:transaction_id) { "fake_transaction_id" }
 
-    subject(:try_void) { gateway.try_void(transaction_id) }
+    subject(:try_void) { gateway.try_void(instance_double('Spree::Payment', response_code: transaction_id)) }
 
     context "when the transaction is found" do
       context "and it is voidable" do


### PR DESCRIPTION
`try_void` is called with a Spree::Payment object, not a charge ID, so we need to extract the charge ID from the payment and pass it to `cancel`.