### PR TITLE
Update css selector for payment step

### DIFF
--- a/app/assets/javascripts/spree/frontend/affirm_checkout.js
+++ b/app/assets/javascripts/spree/frontend/affirm_checkout.js
@@ -26,7 +26,7 @@
           handle continue button clicks with .open()
       \*****************************************************/
       $('#checkout_form_payment').submit(function(e){
-        var checkedPaymentMethod = $('div[data-hook="checkout_payment_step"] input[type="radio"]:checked').val();
+        var checkedPaymentMethod = $('#payment-method-fields input[type="radio"]:checked').val();
         var affirmPaymentMethodId = $("#affirm_checkout_payload").data("paymentgateway")
         if (affirmPaymentMethodId.toString() === checkedPaymentMethod) {
           var $submit_button = $(this).find("input[type='submit']");


### PR DESCRIPTION
When there is already a credit card associated to the user in the payment step, the js code isn't able to recognise the selected `payment_method_id` because there is another radio button(the one which allows you to switch between a saved payment method or a new one).
In this pr I'm changing the css selector from `div[data-hook="checkout_payment_step"]` to `#payment-method-fields`