### PR TITLE
Fix factory girl dependency for Solidus < 2.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,13 +4,23 @@ branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
 
 gem 'solidus', github: 'solidusio/solidus', branch: branch
 
-gem "rails-controller-testing", group: :test
-
-gem 'mysql2'
-gem 'pg', '~> 0.21'
+if ENV['DB'] == 'mysql'
+  gem 'mysql2'
+else
+  gem 'pg', '~> 0.21'
+end
 
 group :development, :test do
   gem "pry-rails"
+end
+
+group :test do
+  gem 'rails-controller-testing'
+  if branch < "v2.5"
+    gem 'factory_bot', '4.10.0'
+  else
+    gem 'factory_bot', '> 4.10.0'
+  end
 end
 
 gemspec


### PR DESCRIPTION
We need to load a factory_bot version that has factory_girl in it
to support Solidus versions < 2.5

This change also includes conditional logic for the database
interface gems.