### PR TITLE
Update to remove deprecation warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ AllCops:
     - 'solidus_affirm.gemspec'
     - 'spec/dummy/**/*'
     - 'vendor/bundle/**/*'
-  TargetRubyVersion: 2.1
+  TargetRubyVersion: 2.2
 
 # Sometimes I believe this reads better
 # This also causes spacing issues on multi-line fixes
@@ -232,4 +232,3 @@ Metrics/BlockLength:
 
 Naming/BinaryOperatorParameterName:
   Enabled: false
-

--- a/Gemfile
+++ b/Gemfile
@@ -15,12 +15,14 @@ group :development, :test do
 end
 
 group :test do
-  gem 'rails-controller-testing'
-  if branch < "v2.5"
-    gem 'factory_bot', '4.10.0'
+  factory_bot_version = if branch < 'v2.5'
+    '4.10.0'
   else
-    gem 'factory_bot', '> 4.10.0'
+    '> 4.10.0'
   end
+
+  gem 'factory_bot', factory_bot_version
+  gem 'rails-controller-testing'
 end
 
 gemspec

--- a/app/models/solidus_affirm/checkout.rb
+++ b/app/models/solidus_affirm/checkout.rb
@@ -1,5 +1,5 @@
 module SolidusAffirm
-  class Checkout < ActiveRecord::Base
+  class Checkout < SolidusSupport.payment_source_parent_class
     self.table_name = "affirm_checkouts"
 
     def actions

--- a/app/models/solidus_affirm/gateway.rb
+++ b/app/models/solidus_affirm/gateway.rb
@@ -1,12 +1,13 @@
 module SolidusAffirm
-  class Gateway < Spree::Gateway
+  class Gateway < ::Spree::PaymentMethod
     preference :public_api_key, :string
     preference :private_api_key, :string
     preference :javascript_url, :string
 
-    def provider_class
+    def gateway_class
       AffirmClient
     end
+    alias_method :provider_class, :gateway_class
 
     def payment_source_class
       SolidusAffirm::Checkout
@@ -16,9 +17,10 @@ module SolidusAffirm
       true
     end
 
-    def method_type
+    def partial_name
       'affirm'
     end
+    alias_method :method_type, :partial_name
 
     def supports?(source)
       source.is_a? payment_source_class
@@ -42,7 +44,7 @@ module SolidusAffirm
     # If the transaction has not yet been captured, we can void the transaction.
     # Otherwise, we need to issue a refund.
     def cancel(charge_id, try_credit = true)
-      provider
+      gateway
 
       begin
         transaction = ::Affirm::Charge.find(charge_id)

--- a/app/models/solidus_affirm/gateway.rb
+++ b/app/models/solidus_affirm/gateway.rb
@@ -1,5 +1,5 @@
 module SolidusAffirm
-  class Gateway < ::Spree::PaymentMethod
+  class Gateway < SolidusSupport.payment_method_parent_class
     preference :public_api_key, :string
     preference :private_api_key, :string
     preference :javascript_url, :string
@@ -44,7 +44,7 @@ module SolidusAffirm
     # If the transaction has not yet been captured, we can void the transaction.
     # Otherwise, we need to issue a refund.
     def cancel(charge_id, try_credit = true)
-      gateway
+      initialize_gateway
 
       begin
         transaction = ::Affirm::Charge.find(charge_id)
@@ -73,6 +73,13 @@ module SolidusAffirm
 
     def voidable?(transaction)
       transaction.status == "authorized"
+    end
+
+    def initialize_gateway
+      # We can just leave gateway after Solidus 2.2 EOL
+      return gateway if respond_to?(:gateway)
+
+      provider
     end
   end
 end

--- a/app/serializers/solidus_affirm/checkout_payload_serializer.rb
+++ b/app/serializers/solidus_affirm/checkout_payload_serializer.rb
@@ -60,6 +60,7 @@ module SolidusAffirm
 
     def metadata
       return nil if object.metadata.empty?
+
       object.metadata
     end
   end

--- a/lib/solidus_affirm/engine.rb
+++ b/lib/solidus_affirm/engine.rb
@@ -18,6 +18,7 @@ module SolidusAffirm
     initializer 'spree.solidus_affirm.action_controller' do |_app|
       ActiveSupport.on_load :action_controller do |klass|
         next if klass.name == "ActionController::API"
+
         helper AffirmHelper
       end
     end

--- a/lib/solidus_affirm/factories/affirm_payment_gateway_factory.rb
+++ b/lib/solidus_affirm/factories/affirm_payment_gateway_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :affirm_payment_gateway, class: SolidusAffirm::Gateway do
-    name "Affirm"
+    name { "Affirm" }
   end
 end

--- a/lib/solidus_affirm/factories/checkout_factory.rb
+++ b/lib/solidus_affirm/factories/checkout_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :affirm_checkout, class: SolidusAffirm::Checkout do
-    token "12345678910"
+    token { "12345678910" }
   end
 end

--- a/solidus_affirm.gemspec
+++ b/solidus_affirm.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'active_model_serializers', '~> 0.10'
   s.add_dependency 'affirm-ruby', '1.0.2'
   s.add_dependency 'solidus', ['>= 2.0', '< 3']
-  s.add_dependency "solidus_support"
+  s.add_dependency "solidus_support", '>= 0.2.2'
 
   s.add_development_dependency 'capybara', '~> 2.18'
   s.add_development_dependency 'coffee-rails'


### PR DESCRIPTION
After https://github.com/solidusio/solidus/pull/2001 we need to change some stuff to remove deprecation warning and be compliant with the next solidus versions. 

This PR also update some code to be rubocop and factor bot compliant.