### PR TITLE
Fix checkout crashing when going back with Affirm

### DIFF
--- a/lib/solidus_affirm/callback_hook/base.rb
+++ b/lib/solidus_affirm/callback_hook/base.rb
@@ -6,7 +6,7 @@ module SolidusAffirm
         authorized_affirm = Affirm::Charge.find(payment.response_code)
         payment.amount = authorized_affirm.amount / 100.0
         payment.save!
-        payment.order.next!
+        payment.order.next! if payment.order.payment?
       end
 
       def after_authorize_url(order)


### PR DESCRIPTION
This fixes a crash that would occur when a user used the back button (or one of the checkout step links) in the :confirm state and switched their payment method to Affirm.

Since in this situation the order is already in the :confirm state when Affirm redirects back to solidus, we are just skipping the `payment.order.next!` transition that otherwise will raise an exception.