### PR TITLE
Make Affirm checkouts non-reusable

### DIFF
--- a/app/models/solidus_affirm/checkout.rb
+++ b/app/models/solidus_affirm/checkout.rb
@@ -2,6 +2,10 @@ module SolidusAffirm
   class Checkout < SolidusSupport.payment_source_parent_class
     self.table_name = "affirm_checkouts"
 
+    def reusable?
+      false
+    end
+
     def actions
       %w(capture void credit)
     end

--- a/spec/models/solidus_affirm/checkout_spec.rb
+++ b/spec/models/solidus_affirm/checkout_spec.rb
@@ -117,4 +117,10 @@ RSpec.describe SolidusAffirm::Checkout do
       end
     end
   end
+
+  describe "#reusable?" do
+    it "is never reusable" do
+      expect(subject.reusable?).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
This PR aims to complete PR #7 by @luukveenis by removing unnecessary commits and rebasing it against current `master`