### PR TITLE
Fix travis issues with sassc and ruby 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ addons:
       - chromium-chromedriver
 
 rvm:
-  - 2.3.1
+  - 2.5.5
 
 services:
   - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,23 @@
 sudo: false
 language: ruby
+
 dist: xenial
 addons:
   chrome: stable
   apt:
     packages:
       - chromium-chromedriver
+
 rvm:
   - 2.3.1
+
+services:
+  - postgresql
+  - mysql
+
 before_install:
   - ln -s /usr/lib/chromium-browser/chromedriver ~/bin/chromedriver
+
 env:
   matrix:
     - SOLIDUS_BRANCH=v2.4 DB=postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: ruby
+dist: xenial
 addons:
   chrome: stable
   apt:

--- a/solidus_affirm.gemspec
+++ b/solidus_affirm.gemspec
@@ -32,7 +32,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'rubocop', '>= 0.38'
   s.add_development_dependency 'rubocop-rspec', '1.4.0'
-  s.add_development_dependency 'sass-rails'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'vcr'


### PR DESCRIPTION
This PR fixes several issues we have, especially with travis:

- `sass-rails` dependency is not needed
- `sassc`compilation needs `libstdc++6` that is already included in `xenial`. No reason not to update it.
- Not sure why (probably on `xenial`) but we now need to start postgres and mysql manually
- Use Ruby 2.5.x since we now have in core some code that needs a Ruby version > 2.4 (to use #finite?)