### PR TITLE
bump affirm-ruby gem to 1.1.0

### DIFF
--- a/solidus_affirm.gemspec
+++ b/solidus_affirm.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir['test/**/*']
 
   s.add_dependency 'active_model_serializers', '~> 0.10'
-  s.add_dependency 'affirm-ruby', '1.0.2'
+  s.add_dependency 'affirm-ruby', '1.1.0'
   s.add_dependency 'solidus', ['>= 2.0', '< 3']
   s.add_dependency "solidus_support", '>= 0.2.2'
 


### PR DESCRIPTION
affirm-ruby gem released a new version with looser dependencies
so this can be used with more up-to-date dependend gems.